### PR TITLE
Pad leading zeros on multiplatform

### DIFF
--- a/03-method.Rmd
+++ b/03-method.Rmd
@@ -411,7 +411,7 @@ distance_df <- lapply(path_files, function(file) {
 }) %>%
   bind_rows() %>%
   rename(home = geoid, park = park_id) %>%
-  mutate(home = sprintf("%012s", home))
+  mutate(home = str_pad(home, width = 12, side = "left", pad = "0"))
 write_rds(distance_df, "data/distances.rds")
 ```
 


### PR DESCRIPTION
Turns out the sprintf function does not work the same on Mac and Windows. This should fix a bug where windows users could not join the datasets correctly.